### PR TITLE
Updated Start.py : Added blacklisted_elements

### DIFF
--- a/weditor/start.py
+++ b/weditor/start.py
@@ -3,7 +3,7 @@ import json
 import sys
 from microWebSrv import MicroWebSrv
 
-
+blacklisted_elements = ["/webrepl_cfg.py"]
 DEBUG_PRINT = False
 
 def dprint(string):
@@ -27,8 +27,15 @@ def get_dir(httpClient, httpResponse):
         path = path[:len(path)-1]
     dprint("Listing dir {}".format(path))
     elements = list(os.ilistdir(path))
-    files = [pt[0] for pt in elements if pt[1]==32768 and pt[0] != "webrepl_cfg.py"]
-    dirs = [pt[0] for pt in elements if pt[1]==16384]
+    files = []
+    dirs = []
+    for pt in elements:
+        to_check  = f"/{pt[0]}" if path == "/" else f"{path}/{pt[0]}"
+        if to_check not in blacklisted_elements :
+               if pt[1]==32768:
+                   files.append(pt[0])
+               if pt[1]==16384:
+                   dirs.append(pt[0])
     content = {"files": files, "dirs": dirs}
     
     _respond(httpResponse, content)

--- a/weditor/start.py
+++ b/weditor/start.py
@@ -29,9 +29,9 @@ def get_dir(httpClient, httpResponse):
     elements = list(os.ilistdir(path))
     files = []
     dirs = []
+    prefix = "" if path == "/" else f"{path}"
     for pt in elements:
-        to_check  = f"/{pt[0]}" if path == "/" else f"{path}/{pt[0]}"
-        if to_check not in blacklisted_elements :
+        if f"{prefix}/{pt[0]}" not in blacklisted_elements :
                if pt[1]==32768:
                    files.append(pt[0])
                if pt[1]==16384:


### PR DESCRIPTION
I am sure there will be more elegant ways to do this, but this seems to work.

Changes:
Added a list : blacklisted_elements where all blacklisted items can be added (with path, for example `blacklisted_elements = ["/webrepl_cfg.py", "/lib/microWebSrv.py"] )`

Changed the method of append to `files` and `dirs` so that there is only one pass over the elements. Earlier, the list expansion was passing over elements twice. Should be faster for large folders.